### PR TITLE
fix: dependencies lock file is not found

### DIFF
--- a/.github/workflows/generate-updates.yml
+++ b/.github/workflows/generate-updates.yml
@@ -45,9 +45,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: pnpm
+          cache-dependency-path: scripts/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --filter=./scripts
 
       - name: Generate feed
         run: node ./scripts/generateUpdatesFeed.cjs


### PR DESCRIPTION
This fixes the issues as seen here: https://github.com/GabsEdits/info/actions/runs/10971542475