### PR TITLE
fix(feed): add missing copyright property

### DIFF
--- a/updates/generateUpdatesFeed.ts
+++ b/updates/generateUpdatesFeed.ts
@@ -43,6 +43,7 @@ const feed = new Feed({
     email: "info@vanillaos.org",
     link: "https://vanillaos.org/",
   },
+  copyright: "Copyright (c) Vanilla OS Contributors",
 });
 
 Object.keys(data).forEach((date) => {


### PR DESCRIPTION
Seemed like it was required, based on this error:

`Property 'copyright' is missing in type '{ title: string; description: string; id: string; link: string; language: string; updated: Date; feedLinks: { atom: string; }; author: { name: string; email: string; link: string; }; }' but required in type 'FeedOptions'.`